### PR TITLE
fix(tegra): remove invalid partitions offsets

### DIFF
--- a/meta-mender-tegra/meta-mender-tegra-jetpack5/recipes-bsp/tegra-binaries/tegra-bootfiles_%.bbappend
+++ b/meta-mender-tegra/meta-mender-tegra-jetpack5/recipes-bsp/tegra-binaries/tegra-bootfiles_%.bbappend
@@ -21,5 +21,12 @@ EOF
 }
 
 do_install:append:tegra194() {
-    # Do nothing
+    # Remove invalid start locations from upstream L4T partition layout files that
+    # prevents the Mender data partition to use remaining space.
+    sed -i -e 's#<start_location> 0x708400000 </start_location>##g' \
+           -e 's#<start_location> 0x710800000 </start_location>##g' \
+		   ${D}${datadir}/tegraflash/${PARTITION_LAYOUT_TEMPLATE}
+    sed -i -e 's#<start_location> 0x708400000 </start_location>##g' \
+           -e 's#<start_location> 0x710800000 </start_location>##g' \
+		   ${D}${datadir}/tegraflash/${PARTITION_LAYOUT_EXTERNAL}
 }


### PR DESCRIPTION
This should enable the data partition to grow to use the full disk size.

Meant for the https://github.com/OE4T/meta-mender-community/pull/19 PR.