### PR TITLE
Mender 4 support

### DIFF
--- a/meta-mender-tegra/meta-mender-tegra-jetpack5/recipes-mender/mender-client/mender-client_%.bbappend
+++ b/meta-mender-tegra/meta-mender-tegra-jetpack5/recipes-mender/mender-client/mender-client_%.bbappend
@@ -1,17 +1,1 @@
-EXTRADEPS:tegra = "tegra-bup-payload tegra-uefi-capsules libubootenv-fake mender-update-verifier"
-RDEPENDS:${PN} += "${EXTRADEPS}"
-
-FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
-SRC_URI:remove:mender-persist-systemd-machine-id = " \
-    file://mender-client-set-systemd-machine-id.sh \
-"
-SRC_URI:append:mender-persist-systemd-machine-id = " \
-    file://tegra-mender-client-set-systemd-machine-id.sh \
-    file://efi_systemd_machine_id.sh \
-"
-
-do_install:prepend:class-target:mender-persist-systemd-machine-id() {
-    install -d -m 755 ${D}${bindir}
-    install -m 755 ${WORKDIR}/efi_systemd_machine_id.sh ${D}${bindir}/
-    cp ${WORKDIR}/tegra-mender-client-set-systemd-machine-id.sh ${WORKDIR}/mender-client-set-systemd-machine-id.sh 
-}
+require mender-tegra.inc

--- a/meta-mender-tegra/meta-mender-tegra-jetpack5/recipes-mender/mender-client/mender-tegra.inc
+++ b/meta-mender-tegra/meta-mender-tegra-jetpack5/recipes-mender/mender-client/mender-tegra.inc
@@ -1,0 +1,17 @@
+EXTRADEPS:tegra = "tegra-bup-payload tegra-uefi-capsules libubootenv-fake mender-update-verifier"
+RDEPENDS:${PN} += "${EXTRADEPS}"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI:remove:mender-persist-systemd-machine-id = " \
+    file://mender-client-set-systemd-machine-id.sh \
+"
+SRC_URI:append:mender-persist-systemd-machine-id = " \
+    file://tegra-mender-client-set-systemd-machine-id.sh \
+    file://efi_systemd_machine_id.sh \
+"
+
+do_install:prepend:class-target:mender-persist-systemd-machine-id() {
+    install -d -m 755 ${D}${bindir}
+    install -m 755 ${WORKDIR}/efi_systemd_machine_id.sh ${D}${bindir}/
+    cp ${WORKDIR}/tegra-mender-client-set-systemd-machine-id.sh ${WORKDIR}/mender-client-set-systemd-machine-id.sh 
+}

--- a/meta-mender-tegra/meta-mender-tegra-jetpack5/recipes-mender/mender-client/mender_%.bbappend
+++ b/meta-mender-tegra/meta-mender-tegra-jetpack5/recipes-mender/mender-client/mender_%.bbappend
@@ -1,0 +1,5 @@
+require mender-tegra.inc
+
+FILES:mender-update:append:mender-persist-systemd-machine-id = " \
+    ${bindir}/efi_systemd_machine_id.sh \
+"


### PR DESCRIPTION
This enables the persistent machine id service to work correctly with mender 4